### PR TITLE
Fixes and extra features added over the years

### DIFF
--- a/classes/BaseWsdlWriter.php
+++ b/classes/BaseWsdlWriter.php
@@ -154,8 +154,10 @@ class BaseWsdlWriter extends DomDocument
         $wsdlSequence = $this->createElement("sequence");
 
         // Create WSDL Elements
+        /* @var $elements WsdlProperty[] */
         $elements     = $wsdlType->getElements();
         foreach ($elements as &$element) {
+            /* @var $element WsdlProperty */
             $wsdlElement = $this->createElement("element");
             $wsdlElement->setAttribute("name", $element->name);
             if (WsdlType::isPrimitiveType($element->type)) {
@@ -163,7 +165,10 @@ class BaseWsdlWriter extends DomDocument
             } else {
                 $wsdlElement->setAttribute("type", "tns:" . $element->type);
             }
-
+            if($element->usage && $element->usage=='optional'){
+              $wsdlElement->setAttribute("minOccurs", "0");
+            }
+            
             // Add WSDL Element to the Sequence
             $wsdlSequence->appendChild($wsdlElement);
         }
@@ -268,8 +273,8 @@ class BaseWsdlWriter extends DomDocument
         $binding  = $this->getBinding();
 
         $definition    = $this->getDefinitionName();
-        $soapAction    = "urn:{$definition}#{$definition}Server#{$operation->name}";
-
+        $soapAction    = $this->getWsdlDefinition()->getNameSpace()."{$operation->name}";
+        
         // Create a new WSDL Operation
         $wsdlOperation = $this->createElement("operation");
         $wsdlOperation->setAttribute("name", $operation->name);
@@ -583,9 +588,12 @@ class BaseWsdlWriter extends DomDocument
      */
     public function getClassName()
     {
-        $className = $this->getWsdlDefinition()->getClassFileName();
-        $className = basename($className, ".inc");
-        $className = basename($className, ".php");
+        $className = $this->getWsdlDefinition()->getClassName();
+        if(!$className){
+          $className = $this->getWsdlDefinition()->getClassFileName();
+          $className = basename($className, ".inc");
+          $className = basename($className, ".php");
+        }
 
         return $className;
     }

--- a/classes/WsdlDefinition.php
+++ b/classes/WsdlDefinition.php
@@ -26,7 +26,10 @@ class WsdlDefinition
     /** @var string */
     private $classFileName;
 
+    /** @var string */
+    private $className;
 
+ 
     /** @var string */
     private $wsdlFileName;
 
@@ -46,8 +49,10 @@ class WsdlDefinition
     /** @var string */
     private $baseUrl;
 
-
-
+    /** @var string[] */
+    private $typeMapping = array();
+    
+ 
     /**
      * Get the value of classFileName
      *
@@ -56,6 +61,26 @@ class WsdlDefinition
     public function getClassFileName()
     {
         return $this->classFileName;
+    }
+
+    /**
+     * Set the value of className
+     *
+     * @param string $className The value of className
+     */
+    public function setClassName($className)  
+    {
+        $this->className = $className;
+    }
+
+    /**
+     * Get the value of className
+     *
+     * @return string The value of className
+     */
+    public function getClassName()  
+    {
+        return $this->className;
     }
 
     /**
@@ -172,6 +197,27 @@ class WsdlDefinition
     public function setBaseUrl($baseUrl)
     {
         $this->baseUrl = $baseUrl;
+    }
+
+ 
+    /**
+     * Get the value of typeMapping
+     *
+     * @return string[] The typeMapping as assoc array
+     */
+    public function getTypeMapping()  
+    {
+        return $this->typeMapping;
+    }
+
+    /**
+     * Set the value of typeMapping
+     *
+     * @param string[] $mapping The value of typeMapping
+     */
+    public function setTypeMapping($mapping)  
+    {
+        $this->typeMapping = $mapping;
     }
 
 }

--- a/classes/WsdlMethod.php
+++ b/classes/WsdlMethod.php
@@ -10,6 +10,7 @@
  */
 
 require_once("WsdlPart.php");
+require_once("WsdlType.php");
 
 /**
  * WSDL Generator for PHP5
@@ -25,6 +26,8 @@ class WsdlMethod
     private $desc        = null;
     private $header      = false;
     private $reqHeaders  = array();
+    
+    private $typeMapping = array();
 
     private $params      = array();
     private $returnType  = null;
@@ -58,6 +61,16 @@ class WsdlMethod
     public function setDesc($desc)
     {
         $this->desc = $desc;
+    }
+
+    /**
+     * Set the Description of the Method
+     *
+     * @param string[] $mapping Assoc array with type mapping old => new
+     */
+    public function setTypeMappings($mapping)
+    {
+        $this->typeMapping = $mapping;
     }
 
     /**
@@ -122,7 +135,17 @@ class WsdlMethod
     public function addParameter($varType, $varName, $varDesc)
     {
         $param = new StdClass();
-
+        if (WsdlType::isArrayTypeClass($varType)) {
+          $varTypeCheck = WsdlType::stripArrayNotation($varType);
+          if(array_key_exists($varTypeCheck,$this->typeMapping)){
+            $varType = $this->typeMapping[$varTypeCheck].'[]';
+          }
+        }else{
+          if(array_key_exists($varType,$this->typeMapping)){
+            $varType = $this->typeMapping[$varType];
+          }
+        }
+        
         $param->type = $varType;
         $param->name = $varName;
         $param->desc = $varDesc;
@@ -138,6 +161,17 @@ class WsdlMethod
      */
     public function setReturn($varType, $varDesc)
     {
+        if (WsdlType::isArrayTypeClass($varType)) {
+          $varTypeCheck = WsdlType::stripArrayNotation($varType);
+          if(array_key_exists($varTypeCheck,$this->typeMapping)){
+            $varType = $this->typeMapping[$varTypeCheck].'[]';
+          }
+        }else{
+          if(array_key_exists($varType,$this->typeMapping)){
+            $varType = $this->typeMapping[$varType];
+          }
+        }
+        
         $this->returnType = $varType;
         $this->returnDesc = $varDesc;
     }

--- a/classes/WsdlProperty.php
+++ b/classes/WsdlProperty.php
@@ -23,6 +23,7 @@ class WsdlProperty
     public $type               = null;
     public $name               = null;
     public $description        = null;
+    public $usage              = null;
 
 
     public function setName($name)
@@ -43,6 +44,11 @@ class WsdlProperty
     public function setDesc($desc)
     {
         $this->description = $desc;
+    }
+
+    public function setUsage($usage)
+    {
+        $this->usage = $usage;
     }
 
 }


### PR DESCRIPTION
I have just created a pull request with all the changes we made to the wsdl-writer over the years. Feel free to merge them in (or not) or cherry-pick.  Below are the changes contained in this PR.

Allow creation of webservices with mapped class names, so we do not
expose internal class names.
- WsdlDefinition: add new method setTypeMapping() and getTypeMapping().
  The typeMapping is an assoc array with as key a php class name and
  as value the new type name. The mapping is stored in this wsdl
  definition in a new private property.
- WsdlWriter: now in several places pass the new classmapping from the
  wsdl definition to sub-modules.
- WsdlType:
  -- add new private property orgClassName, it will be set from a new,
     optional, constructor param.
  -- made the private static method stripArrayNotation public (static).
     No idea why it was private, which is weird for a static method anyway.
  -- findComplexTypes: because it tries to reflect the types (which
     already have been possibly mapped) we need to revert the mapping
     just for the reflection. So the method has a new optional param
     with the class mapping.
  -- getComplexTypes: it calls the above method and aslo creates
     WsdlType objects so it needs to use mapped classnames (in fact
     to find the original php classname).
  -- getProperties: because the method tries to reflect the type, it
     needs the original php classname.
- WsdlMethod: parameter types and return types will be mapped from php
  classnames to chosen type names when the (new) setTypeMappings()
  method has been called with a mapping. We use some WsdlType static
  methods to detect array types because arrays are postfixed with []
  array notation, which ofcource cannot be found in the mapping array.
  So we need to strip array notation, look up in mapping and ad it
  again if needed.

Remove function split() for improved PHP compatibility.

Added parsing of docblocks for class properties, now also detects
@internal tag so properties can be optional in the wsdl.

Added support for optional properties. When the docblock of a class
property contains "@internal optional" then in the wsdl the following
property is added: minOccurs="0"

Change the soapaction URI format to be conform rfc

Added binary, float,date/time primitive types to WsdlType class.

Allow '@internal ignore' docblock var. any method containing this will
not be exposed, even if its public.

The wsdlDefinition can now set the className for situations where
classname and classfile are different.